### PR TITLE
Improve orbit handling to reduce duplicate automorphisms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ set(BLISS_SOURCES
     src/bliss_io.c
     src/bliss_partition.c      # NEW
     src/bliss_refinement.c     # NEW
-	src/bliss_unified.c
+    src/bliss_unified.c
+    src/orbit.c
 )
 
 set(BLISS_HEADERS

--- a/include/bliss.h
+++ b/include/bliss.h
@@ -201,6 +201,10 @@ void* bliss_realloc(void* ptr, size_t size);
 void bliss_free(void* ptr);
 unsigned int min_uint(unsigned int a, unsigned int b);
 unsigned int max_uint(unsigned int a, unsigned int b);
+void orbit_init(search_state_t *state, unsigned int n);
+unsigned int orbit_find(const search_state_t *state, unsigned int v);
+void orbit_union(search_state_t *state, unsigned int a, unsigned int b);
+void orbit_free(search_state_t *state);
 
 /* Partition operations */
 partition_t *partition_new(unsigned int num_vertices);

--- a/src/bliss_core.c
+++ b/src/bliss_core.c
@@ -410,6 +410,9 @@ static void search_automorphisms_recursive(bliss_graph_t *graph,
             }
             
             state->generators[state->num_generators] = automorphism;
+            for (unsigned int i = 0; i < graph->num_vertices; i++) {
+                orbit_union(state, i, automorphism[i]);
+            }
             state->num_generators++;
             state->stats->nof_generators++;
         } else {
@@ -546,6 +549,7 @@ void bliss_find_automorphisms_incomplete(bliss_graph_t *graph,
     state->generator_capacity = 16;
     state->generators = bliss_malloc(state->generator_capacity * sizeof(unsigned int*));
     state->num_generators = 0;
+    orbit_init(state, graph->num_vertices);
     
     /* Create initial partition based on vertex colors */
     state->root = bliss_malloc(sizeof(search_node_t));
@@ -653,6 +657,9 @@ void search_automorphisms_with_individualization(bliss_graph_t *graph,
             }
 
             state->generators[state->num_generators] = automorphism;
+            for (unsigned int i = 0; i < graph->num_vertices; i++) {
+                orbit_union(state, i, automorphism[i]);
+            }
             state->num_generators++;
             state->stats->nof_generators++;
         } else {
@@ -799,6 +806,7 @@ void bliss_find_automorphisms_complete(bliss_graph_t *graph,
         bliss_free(state->generators[i]);
     }
     bliss_free(state->generators);
+    orbit_free(state);
     bliss_free(state->best_path);
 
     partition_release(&state->root->partition);
@@ -853,6 +861,9 @@ static void search_automorphisms_improved(bliss_graph_t* graph,
       }
 
       state->generators[state->num_generators] = automorphism;
+      for (unsigned int i = 0; i < graph->num_vertices; i++) {
+        orbit_union(state, i, automorphism[i]);
+      }
       state->num_generators++;
       state->stats->nof_generators++;
     }

--- a/src/bliss_partition.c
+++ b/src/bliss_partition.c
@@ -346,25 +346,15 @@ partition_t *individualize_vertex(const partition_t *original_partition,
 bool vertices_in_same_orbit(unsigned int v1, unsigned int v2,
                            const search_state_t *state,
                            const bliss_graph_t *graph) {
-    /* Suppress unused parameter warning */
-    (void)state; /* ADD THIS LINE */
-    
-    /* Basic orbit check - in a complete implementation, this would use
-     * the accumulated automorphism generators to compute orbits */
-    
-    /* If vertices have different colors, they cannot be in the same orbit */
-    if (graph->vertex_colors[v1] != graph->vertex_colors[v2]) {
+    if (!state || !state->orbit)
         return false;
-    }
-    
-    /* If vertices have different degrees, they cannot be in the same orbit */
-    if (graph->adj_list_sizes[v1] != graph->adj_list_sizes[v2]) {
+
+    if (graph->vertex_colors[v1] != graph->vertex_colors[v2])
         return false;
-    }
-    
-    /* TODO: More sophisticated orbit computation using generators */
-    /* For now, conservatively assume different orbits */
-    return false;
+
+    unsigned int r1 = orbit_find(state, v1);
+    unsigned int r2 = orbit_find(state, v2);
+    return r1 == r2;
 }
 
 

--- a/src/bliss_unified.c
+++ b/src/bliss_unified.c
@@ -335,6 +335,9 @@ static void search_automorphisms_unified(bliss_graph_t *graph,
                 }
 
                 state->generators[state->num_generators] = automorphism;
+                for (unsigned int i = 0; i < graph->num_vertices; i++) {
+                  orbit_union(state, i, automorphism[i]);
+                }
                 state->num_generators++;
                 state->stats->nof_generators++;
 #if BLISS_DEBUG&2
@@ -458,6 +461,7 @@ void bliss_find_automorphisms_unified(bliss_graph_t *graph,
     state->generator_capacity = 16;
     state->generators = bliss_malloc(state->generator_capacity * sizeof(unsigned int*));
     state->num_generators = 0;
+    orbit_init(state, graph->num_vertices);
     
     /* Create initial partition based on vertex colors */
     state->root = bliss_malloc(sizeof(search_node_t));
@@ -614,6 +618,7 @@ void bliss_find_automorphisms_unified(bliss_graph_t *graph,
         bliss_free(state->generators[i]);
     }
     bliss_free(state->generators);
+    orbit_free(state);
     bliss_free(state->best_path);
     
     partition_free_contents(&state->root->partition);

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -1,0 +1,42 @@
+#include "bliss.h"
+
+void orbit_init(search_state_t *state, unsigned int n) {
+    state->orbit = bliss_malloc(n * sizeof(unsigned int));
+    state->orbit_size = bliss_malloc(n * sizeof(unsigned int));
+    for (unsigned int i = 0; i < n; i++) {
+        state->orbit[i] = i;
+        state->orbit_size[i] = 1;
+    }
+}
+
+static unsigned int orbit_find_internal(search_state_t *state, unsigned int v) {
+    while (state->orbit[v] != v) {
+        state->orbit[v] = state->orbit[state->orbit[v]];
+        v = state->orbit[v];
+    }
+    return v;
+}
+
+unsigned int orbit_find(const search_state_t *state, unsigned int v) {
+    return orbit_find_internal((search_state_t *)state, v);
+}
+
+void orbit_union(search_state_t *state, unsigned int a, unsigned int b) {
+    unsigned int ra = orbit_find_internal(state, a);
+    unsigned int rb = orbit_find_internal(state, b);
+    if (ra == rb) return;
+    if (state->orbit_size[ra] < state->orbit_size[rb]) {
+        unsigned int tmp = ra;
+        ra = rb;
+        rb = tmp;
+    }
+    state->orbit[rb] = ra;
+    state->orbit_size[ra] += state->orbit_size[rb];
+}
+
+void orbit_free(search_state_t *state) {
+    bliss_free(state->orbit);
+    bliss_free(state->orbit_size);
+    state->orbit = NULL;
+    state->orbit_size = NULL;
+}


### PR DESCRIPTION
## Summary
- add basic union–find orbit tracking implementation
- expose new orbit helpers in the public header
- store orbit information whenever a generator is kept
- initialise and free orbit arrays in search state
- use orbit tracking when checking if two vertices are in the same orbit

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: LPFoldingTests, ClassicGraphTests)*


------
https://chatgpt.com/codex/tasks/task_e_68555b727ee4832684b2fd0f55c0259c